### PR TITLE
Reload method and better tests around memory management

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Read IP data from MaxMind DB files",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --expose-gc"
+    "test": "mocha test/geoip-test.js test/reader-test.js && node --expose-gc test/memory-test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Read IP data from MaxMind DB files",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --expose-gc"
   },
   "repository": {
     "type": "git",

--- a/src/LRUCache.js
+++ b/src/LRUCache.js
@@ -5,14 +5,18 @@ function Entry(key, value, lu){
 }
 
 function LRUCache(limit){
+  this._limit = limit;
+  this.reset();
+}
+
+LRUCache.prototype.reset = function(){
   this._cache = {};
   this._list = {};
   this._lru = 0;
   this._mru = 0;
   this._waiting = 0;
   this._count = 0;
-  this._limit = limit;
-}
+};
 
 LRUCache.prototype.get = function(key){
   var entry = this._cache[key];

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -72,6 +72,7 @@ Reader.prototype.reload = function(file, cb){
         return;
       }
       self.reload(buf);
+      cb(null);
     });
     return;
   }

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -53,6 +53,12 @@ Reader.open = function(file, cb){
 
 Reader.openSync = Reader;
 
+Reader.prototype.destroy = function(){
+  this._buf = null;
+  this._pointerCache = null;
+  this.metadata = null;
+  this.ip = null;
+};
 
 Reader.prototype._read = function(ptr){
   return this._buf[ptr];

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -43,13 +43,6 @@ Reader.open = function(file, cb){
 
 Reader.openSync = Reader;
 
-Reader.prototype.destroy = function(){
-  this._buf = null;
-  this._pointerCache = null;
-  this.metadata = null;
-  this.ip = null;
-};
-
 Reader.prototype.setup = function(){
   var metaPosition = this.findMetaPosition();
   this.metadata = this.readData(metaPosition).value;

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -1,7 +1,7 @@
 /*eslint-env mocha */
 
 if(typeof gc === 'undefined'){
-  throw new Error("Destroy test should be run with --expose-gc");
+  throw new Error("Memory test should be run with --expose-gc");
 }
 
 console.log('Running memory test...');
@@ -22,19 +22,18 @@ console.log('Initial RSS: %s', start.rss);
 
 var num = 5000;
 
+// TEST DESTROY
+console.log('\nTesting destroying...');
+
 // Do a few loops of loading lots of stuff into mem and getting rid of it
 
 for(var j = 0; j < 10; j += 1){
 
-  readers.forEach(function(r){
-    r.destroy();
-  });
+  readers.forEach(function(r){ r.destroy(); });
 
   gc();
 
-  for(var i = 0; i < num; i++){
-    readers.push(new Reader(file));
-  }
+  for(var i = 0; i < num; i++) readers.push(new Reader(file));
 
   gc();
 
@@ -50,3 +49,36 @@ for(var j = 0; j < 10; j += 1){
 }
 
 // If we actually get to this point without crashing, it must have worked
+console.log('Good!\n');
+
+readers = [];
+
+gc();
+
+// TEST RELOAD
+console.log('\nTesting reloading...');
+
+for(var i = 0; i < num; i++) readers.push(new Reader(file));
+
+
+for(var j = 0; j < 10; j += 1){
+
+  readers.forEach(function(r){
+    r.reloadSync(file);
+    assert.strictEqual(r.lookup('1.128.0.0').isp, 'Telstra Internet');
+  });
+
+  gc();
+
+  var mem = process.memoryUsage();
+
+  console.log('Pass %s RSS: %s', j, mem.rss);
+
+  // We've loaded ${num} copies of the file into mem, they should be there
+  assert(mem.rss - start.rss > num * fileSize);
+
+  // Dispose + gc + reload shouldn't increase the mem too much
+  assert(mem.rss - start.rss < num * fileSize * 1.5);
+}
+
+console.log('Good!');

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -42,7 +42,8 @@ for(var j = 0; j < 10; j += 1){
   console.log('Pass %s RSS: %s', j, mem.rss);
 
   // We've loaded ${num} copies of the file into mem, they should be there
-  assert(mem.rss - start.rss > num * fileSize);
+  // 0.75 in case initial RSS was a bit high.
+  assert(mem.rss - start.rss > num * fileSize * 0.75);
 
   // Dispose + gc + reload shouldn't increase the mem too much
   assert(mem.rss - start.rss < num * fileSize * 1.5);
@@ -75,7 +76,8 @@ for(var j = 0; j < 10; j += 1){
   console.log('Pass %s RSS: %s', j, mem.rss);
 
   // We've loaded ${num} copies of the file into mem, they should be there
-  assert(mem.rss - start.rss > num * fileSize);
+  // 0.75 in case initial RSS was a bit high.
+  assert(mem.rss - start.rss > num * fileSize * 0.75);
 
   // Dispose + gc + reload shouldn't increase the mem too much
   assert(mem.rss - start.rss < num * fileSize * 1.5);

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -23,13 +23,13 @@ console.log('Initial RSS: %s', start.rss);
 var num = 5000;
 
 // TEST DESTROY
-console.log('\nTesting destroying...');
+console.log('\nTesting cleanup...');
 
-// Do a few loops of loading lots of stuff into mem and getting rid of it
+// Do a few loops of loading lots of stuff into mem and chucking it away
 
 for(var j = 0; j < 10; j += 1){
 
-  readers.forEach(function(r){ r.destroy(); });
+  readers = [];
 
   gc();
 

--- a/test/zzz-memory-test.js
+++ b/test/zzz-memory-test.js
@@ -1,0 +1,52 @@
+/*eslint-env mocha */
+
+if(typeof gc === 'undefined'){
+  throw new Error("Destroy test should be run with --expose-gc");
+}
+
+console.log('Running memory test...');
+
+var assert = require('assert');
+
+var Reader = require('../');
+
+var fs = require('fs');
+var file = 'test/data/GeoIP2-Precision-ISP-Test.mmdb';
+var fileSize = fs.statSync(file).size;
+
+var readers = [];
+
+var start = process.memoryUsage();
+
+console.log('Initial RSS: %s', start.rss);
+
+var num = 5000;
+
+// Do a few loops of loading lots of stuff into mem and getting rid of it
+
+for(var j = 0; j < 10; j += 1){
+
+  readers.forEach(function(r){
+    r.destroy();
+  });
+
+  gc();
+
+  for(var i = 0; i < num; i++){
+    readers.push(new Reader(file));
+  }
+
+  gc();
+
+  var mem = process.memoryUsage();
+
+  console.log('Pass %s RSS: %s', j, mem.rss);
+
+  // We've loaded ${num} copies of the file into mem, they should be there
+  assert(mem.rss - start.rss > num * fileSize);
+
+  // Dispose + gc + reload shouldn't increase the mem too much
+  assert(mem.rss - start.rss < num * fileSize * 1.5);
+}
+
+// If we actually get to this point without crashing, it must have worked


### PR DESCRIPTION
~~If a reader needs to be replaced with a new one (e.g. we've got an updated version of the file), the `destroy()` method will make sure buffers and LRUs aren't kept around.~~

~~Also with tests. No idea if they'll blow up travis or not.~~

**Edit:**

After running through the possible use-cases here and putting together the memory tests, I've realised a `destroy()` method is unnecessary and messy (please slap me if you disagree). Better is just to make sure that unref-ing the reader instance does actually unref everything it's holding onto (the data buffer and its pointer cache). A better way of addressing the "make sure reloading stuff is clean" is the `reload(file[, cb])` method I've added, which takes care of loading the file and setting everything up in such a way that stuff doesn't get inconsistent.