### PR TITLE
Use fast lastIndexOf where available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
 language: node_js
 node_js:
   - stable
+  - '6'
   - '5'
   - '4'
   - '0.12'
   - '0.10'
 
-deploy:
-  provider: npm
-  email: jt@gosquared.com
-  api_key:
-    secure: OEZALcDee2bYXdL/XfbbQV4Kz18M+oqqQGEUyEonb20rDNZab9HAXjiCfF2TCkmAck9h2b9lJm1ahogWqlgRuNq0qKJ41MxSsK8sp31pVlw65xFa3ol0rbS0vxA7BxldFwEVUyqP5lNBRsfCxgf7jJjvD2RSHYTFxqFSElF0HavzpipUZPS1yZ3Z5nPEFsSc3AFhp8rohOYy+X0LiIaRi8+wBNUbObIA9DWmilk9ZgnQQxonRxIjV2kRPvkiiloicOpviLFZNIpWA0FOIda3XWK9yHUrXegAG4h3J70qUkY6X68NxvJGagrZf6DfreqK53lTkuyNab8TIINTLEy2y6cXCPTJ/XEmuyr7iSoNqx5rqzUHvZZy8ck9v0lU5YXeZzsRwpmLA4aBGk0GG+3odE6NBqIVN5bZ7zeEKGSYAsGELOFV5FPU1PurDdOCi/Go7K8u1XWn/6sgFsHkt2Z75Vne1nIiOAdG4YXeyUw2uALI03gDhBYV+64bsibmVB3SPpBO4Doef9v8pLfgJ9hX42WAOkzT3zkmqtm4B+rdpBA0ipDKrPrKp3JDcQE3MqIPGVCYQt2IsNxOxOjSJVXeaWd66AW0ngxg8lASvl2fxeQ/tKBKNamplw6/96D0AqPM6Kbnfi8fEuGKqrvuIuL5gIP3lrINFXarmq/demyNrE8=
-  on:
-    tags: true
-    branch: master
 notifications:
   slack:
     secure: EYYu/Yq77M0chS5m4BVUn7w4ZjovE1pACGXtHkkXMUzFlxD0OjwNMeF+b1CPKgMgVFYA4yCTMthF3dcEytGFedEM79ZdxqP84sfI8oodRkSsiafx/WIdbpjivqfADKeM4DYkVxq2bv+5Jw4TXNGozxYFL2gtsa4AcJ+NkqhMtmB0DFMN8mgccaaYBKH8TsihtwOlgpetD7Jfi/SwShNnhYvYXvW9xL96auX/jsiE7247yjQrdkgDBK6wj6QeLJLou+NE/aaolYzQ/j9FAfjx6F3StD6cLRHWzP4OxtFKgMl6gv4dNB77I2fEzD9RlrHPLnHqfj2qC4IGjeBsE4qbhXpvUYPMtJV9RLNZce2NaTmb3T1oUsVvsjv/6ThL137CnlxgdAPi07ABK/YRcdIvoN1PuTjBvtqhY19+q2bfq/+zLA5LVK4jFRmfPxwGXAODB3huaNfH/J4s+oDaiEMBzC9KDnuOS99P7tqDHyiBbTgz0/2eEzk+05kBSpmcIUTNXUumHqjh/7C0tZ4Bz9RC1lwgERUBcEpxi0SQbmJQ17uwm62wXuAVsmxm8E/AfF/s6s1z6yBGyE6krntqonFwqPJlnkjAt9te8kosEVOg372OhMAapkOy5Uy4RlgJ2W+uNPRqpG28H8PmgiW4HZ3TcUZe3Htn/sgOrBMnfJKadmI=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmdb-reader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Read IP data from MaxMind DB files",
   "main": "index.js",
   "scripts": {

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -238,7 +238,7 @@ Reader.prototype.findMetaPosition = function() {
     }
 
     // If we reached the beginning of the file, something went wrong
-    if (metaPosition === -1) {
+    if (metaPosition === 0) {
       throw new Error('Bad DB');
     }
   }

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -75,12 +75,13 @@ describe('Bad DBs', function() {
   it('throws up when loading a nonexistent file (sync)', function() {
     assert.throws(function() {
       Reader('does/not/exist'); // eslint-disable-line new-cap
-    });
+    }, /ENOENT/);
   });
 
   it('throws up when loading a nonexistent file (async)', function(done) {
     Reader.open('does/not/exist', function(err) {
       assert(err);
+      assert(/ENOENT/.test(err.message));
       done();
     });
   });
@@ -88,12 +89,13 @@ describe('Bad DBs', function() {
   it('doesn\'t get confused by a bad db file', function() {
     assert.throws(function() {
       Reader('test/data/empty.mmdb'); // eslint-disable-line new-cap
-    });
+    }, /Bad DB/);
   });
 
   it('doesn\'t get confused by a bad db file (async)', function(done) {
     Reader.open('test/data/empty.mmdb', function(err) {
       assert(err);
+      assert(/Bad DB/.test(err.message));
       done();
     });
   });
@@ -105,7 +107,7 @@ describe('Bad DBs', function() {
 
     assert.throws(function() {
       reader.reloadSync('test/data/empty.mmdb');
-    });
+    }, /Bad DB/);
   });
 
   it('throws up when reloading a bad file (async)', function(done) {
@@ -115,6 +117,7 @@ describe('Bad DBs', function() {
 
     reader.reload('test/data/empty.mmdb', function(err) {
       assert(err);
+      assert(/Bad DB/.test(err.message));
       done();
     });
   });

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -88,7 +88,7 @@ for (j = 0; j < 10; j += 1) {
   assert(mem.rss - start.rss > num * fileSize * 0.75);
 
   // Dispose + gc + reload shouldn't increase the mem too much
-  assert(mem.rss - start.rss < num * fileSize * 1.5);
+  assert(mem.rss - start.rss < num * fileSize * 1.75);
 }
 
 console.log('Good!');


### PR DESCRIPTION
 * Uses fast Buffer#lastIndexOf when available (node v6). Closes #10
 * Adds Node v6 to travis config
 * Tweaks to mem test threshold because Node v6 GC is less aggressive
 * Removed npm publish from Travis because it was being weird

Yes, I accidentally pushed this to master before it was ready. I shouldn't be allowed near code late on a Friday evening. This is take two.