### PR TITLE
IPv4 mapped to IPv6 address support, ie "::ffff:0:10.10.10.10" and "::ffff:10.10.10.10"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   },
   "dependencies": {
     "big-integer": "^1.5.4",
-    "hashlru": "^2.0.0"
+    "sinon": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "big-integer": "^1.5.4",
+    "hashlru": "^2.2.1",
     "sinon": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "big-integer": "^1.5.4",
     "hashlru": "^2.0.0",
-    "sinon": "^4.4.6"
+    "sinon": "4.4.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "big-integer": "^1.5.4",
     "hashlru": "^2.0.0",
-    "sinon": "4.4.6"
+    "sinon": "4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "big-integer": "^1.5.4",
-    "hashlru": "^2.2.1",
-    "sinon": "^6.0.1"
+    "hashlru": "^2.0.0",
+    "sinon": "^4.4.6"
   }
 }

--- a/src/IpDecoder.js
+++ b/src/IpDecoder.js
@@ -10,12 +10,17 @@ function IpDecoder() {
   this.ipVersion = 4;
 }
 
+// @see "Special address blocks" at https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv6, "IPv4 mapped addresses." and "IPv4 translated addresses."
+IpDecoder.prototype.ipv4HybridTest = /^\:\:ffff\:(0\:){0,1}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
 // Set an IP string and store it in the buffer. This method
 // assumes you've already validated the IP and it's sane
 IpDecoder.prototype.set = function(ip) {
+  var mappedIPv4 = ip.match(IpDecoder.prototype.ipv4HybridTest);
 
-  // Super-naive test for IPv4. TODO: check IPv6-mapped IPv4
-  if (ip.charAt(3) === '.' || ip.charAt(2) === '.' || ip.charAt(1) === '.') {
+  if (mappedIPv4 && mappedIPv4.length === 6) {
+    this.set4(mappedIPv4.slice(2).join('.')); // convert back to ipV4
+  } else if (ip.charAt(3) === '.' || ip.charAt(2) === '.' || ip.charAt(1) === '.') {
     this.set4(ip);
   } else {
     this.set6(ip);

--- a/test/reader-test.js
+++ b/test/reader-test.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 var assert = require('assert');
+var sinon = require('sinon');
 
 var Reader = require('../');
 
@@ -96,6 +97,25 @@ function checkIPv6(reader) {
   [ '1.1.1.33', '255.254.253.123', '89fa::' ].forEach(function(addr) {
     it('expects null for ' + addr, function() {
       assert.equal(reader.lookup(addr), null);
+    });
+  });
+
+  describe('IPv4 as IPv6', function() {
+    var spy;
+    beforeEach(function() {
+      spy = sinon.spy(reader.ip, 'set4');
+    });
+    afterEach(function() {
+      reader.ip.set4.restore();
+    });
+    it('IPv4 "translated" addresses should be looked up in the v4 DB', function() {
+      reader.lookup('::ffff:0:10.10.10.10');
+      assert(spy.calledWith('10.10.10.10'));
+    });
+
+    it('IPv4 "mapped" addresses should be looked up in the v4 DB', function() {
+      reader.lookup('::ffff:10.10.10.10');
+      assert(spy.calledWith('10.10.10.10'));
     });
   });
 }


### PR DESCRIPTION
- added support for IPv4 Mapped + Translated strings
   - See https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv6
- Added test cases (uses `sinon` to spy on v4 lookup to make sure it is called w/ special cases)
- Added .editorconfig w/ 2 spaces   

| Address block (CIDR) | First address      | Last address               | Number of addresses                                          | Usage    | Purpose                    |
| -------------------- | ------------------ | -------------------------- | ------------------------------------------------------------ | -------- | -------------------------- |
| *::ffff:0:0/96*      | *::ffff:0.0.0.0*   | *::ffff:255.255.255.255*   | [2128-96 = 232](https://en.wikipedia.org/wiki/Power_of_2) = 4294967296 | Software | IPv4 mapped addresses.     |
| *::ffff:0:0:0/96*    | *::ffff:0:0.0.0.0* | *::ffff:0:255.255.255.255* | 232                                                          | Software | IPv4 translated addresses. |

## Test Results = Pass:
/usr/local/bin/node /usr/local/lib/node_modules/npm/bin/npm-cli.js test --scripts-prepend-node-path=auto

> mmdb-reader@1.1.0 test /Users/cwagner/Sites/mmdb-reader
> eslint . && mocha test/geoip-test.js test/reader-test.js test/api-test.js && node --max-old-space-size=32 --expose-gc test/memory-test.js


/Users/cwagner/Sites/mmdb-reader/test/geoip-test.js
  64:1  warning  Unexpected "todo" comment  no-warning-comments

/Users/cwagner/Sites/mmdb-reader/test/memory-test.js
  75:19  warning  Don't make functions within a loop  no-loop-func

/Users/cwagner/Sites/mmdb-reader/test/reader-test.js
  14:5  warning  Unexpected "todo" comment  no-warning-comments

✖ 3 problems (0 errors, 3 warnings)



  Anonymous IP
    ✓ works

  Connection Type
    ✓ works

  Domain
    ✓ works

  ISP
    ✓ works

  Country
    ✓ works

  City
    ✓ works

  24-bit record size
    IP version: 4
      ✓ has all the correct metadata
      ✓ finds expected record for 1.1.1.1
      ✓ finds expected record for 1.1.1.2
      ✓ finds expected record for 1.1.1.4
      ✓ finds expected record for 1.1.1.8
      ✓ finds expected record for 1.1.1.16
      ✓ finds expected record for 1.1.1.32
      ✓ finds expected record for 1.1.1.3
      ✓ finds expected record for 1.1.1.5
      ✓ finds expected record for 1.1.1.7
      ✓ finds expected record for 1.1.1.9
      ✓ finds expected record for 1.1.1.15
      ✓ finds expected record for 1.1.1.17
      ✓ finds expected record for 1.1.1.31
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
    IP version: 6
      ✓ has all the correct metadata
      ✓ finds expected record for ::1:ffff:ffff
      ✓ finds expected record for ::2:0:0
      ✓ finds expected record for ::2:0:40
      ✓ finds expected record for ::2:0:50
      ✓ finds expected record for ::2:0:58
      ✓ finds expected record for ::2:0:1
      ✓ finds expected record for ::2:0:33
      ✓ finds expected record for ::2:0:39
      ✓ finds expected record for ::2:0:41
      ✓ finds expected record for ::2:0:49
      ✓ finds expected record for ::2:0:52
      ✓ finds expected record for ::2:0:57
      ✓ finds expected record for ::2:0:59
      ✓ finds expected record for 0:0:0:0:0:2:0:59
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ expects null for 89fa::
      IPv4 as IPv6
        ✓ IPv4 "translated" addresses should be looked up in the v4 DB
        ✓ IPv4 "mapped" addresses should be looked up in the v4 DB
    IP version: mixed
      ✓ has all the correct metadata
      ✓ finds expected record for 1.1.1.1
      ✓ finds expected record for 1.1.1.2
      ✓ finds expected record for 1.1.1.4
      ✓ finds expected record for 1.1.1.8
      ✓ finds expected record for 1.1.1.16
      ✓ finds expected record for 1.1.1.32
      ✓ finds expected record for 1.1.1.3
      ✓ finds expected record for 1.1.1.5
      ✓ finds expected record for 1.1.1.7
      ✓ finds expected record for 1.1.1.9
      ✓ finds expected record for 1.1.1.15
      ✓ finds expected record for 1.1.1.17
      ✓ finds expected record for 1.1.1.31
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ finds expected record for ::1:ffff:ffff
      ✓ finds expected record for ::2:0:0
      ✓ finds expected record for ::2:0:40
      ✓ finds expected record for ::2:0:50
      ✓ finds expected record for ::2:0:58
      ✓ finds expected record for ::2:0:1
      ✓ finds expected record for ::2:0:33
      ✓ finds expected record for ::2:0:39
      ✓ finds expected record for ::2:0:41
      ✓ finds expected record for ::2:0:49
      ✓ finds expected record for ::2:0:52
      ✓ finds expected record for ::2:0:57
      ✓ finds expected record for ::2:0:59
      ✓ finds expected record for 0:0:0:0:0:2:0:59
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ expects null for 89fa::
      IPv4 as IPv6
        ✓ IPv4 "translated" addresses should be looked up in the v4 DB
        ✓ IPv4 "mapped" addresses should be looked up in the v4 DB

  28-bit record size
    IP version: 4
      ✓ has all the correct metadata
      ✓ finds expected record for 1.1.1.1
      ✓ finds expected record for 1.1.1.2
      ✓ finds expected record for 1.1.1.4
      ✓ finds expected record for 1.1.1.8
      ✓ finds expected record for 1.1.1.16
      ✓ finds expected record for 1.1.1.32
      ✓ finds expected record for 1.1.1.3
      ✓ finds expected record for 1.1.1.5
      ✓ finds expected record for 1.1.1.7
      ✓ finds expected record for 1.1.1.9
      ✓ finds expected record for 1.1.1.15
      ✓ finds expected record for 1.1.1.17
      ✓ finds expected record for 1.1.1.31
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
    IP version: 6
      ✓ has all the correct metadata
      ✓ finds expected record for ::1:ffff:ffff
      ✓ finds expected record for ::2:0:0
      ✓ finds expected record for ::2:0:40
      ✓ finds expected record for ::2:0:50
      ✓ finds expected record for ::2:0:58
      ✓ finds expected record for ::2:0:1
      ✓ finds expected record for ::2:0:33
      ✓ finds expected record for ::2:0:39
      ✓ finds expected record for ::2:0:41
      ✓ finds expected record for ::2:0:49
      ✓ finds expected record for ::2:0:52
      ✓ finds expected record for ::2:0:57
      ✓ finds expected record for ::2:0:59
      ✓ finds expected record for 0:0:0:0:0:2:0:59
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ expects null for 89fa::
      IPv4 as IPv6
        ✓ IPv4 "translated" addresses should be looked up in the v4 DB
        ✓ IPv4 "mapped" addresses should be looked up in the v4 DB
    IP version: mixed
      ✓ has all the correct metadata
      ✓ finds expected record for 1.1.1.1
      ✓ finds expected record for 1.1.1.2
      ✓ finds expected record for 1.1.1.4
      ✓ finds expected record for 1.1.1.8
      ✓ finds expected record for 1.1.1.16
      ✓ finds expected record for 1.1.1.32
      ✓ finds expected record for 1.1.1.3
      ✓ finds expected record for 1.1.1.5
      ✓ finds expected record for 1.1.1.7
      ✓ finds expected record for 1.1.1.9
      ✓ finds expected record for 1.1.1.15
      ✓ finds expected record for 1.1.1.17
      ✓ finds expected record for 1.1.1.31
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ finds expected record for ::1:ffff:ffff
      ✓ finds expected record for ::2:0:0
      ✓ finds expected record for ::2:0:40
      ✓ finds expected record for ::2:0:50
      ✓ finds expected record for ::2:0:58
      ✓ finds expected record for ::2:0:1
      ✓ finds expected record for ::2:0:33
      ✓ finds expected record for ::2:0:39
      ✓ finds expected record for ::2:0:41
      ✓ finds expected record for ::2:0:49
      ✓ finds expected record for ::2:0:52
      ✓ finds expected record for ::2:0:57
      ✓ finds expected record for ::2:0:59
      ✓ finds expected record for 0:0:0:0:0:2:0:59
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ expects null for 89fa::
      IPv4 as IPv6
        ✓ IPv4 "translated" addresses should be looked up in the v4 DB
        ✓ IPv4 "mapped" addresses should be looked up in the v4 DB

  32-bit record size
    IP version: 4
      ✓ has all the correct metadata
      ✓ finds expected record for 1.1.1.1
      ✓ finds expected record for 1.1.1.2
      ✓ finds expected record for 1.1.1.4
      ✓ finds expected record for 1.1.1.8
      ✓ finds expected record for 1.1.1.16
      ✓ finds expected record for 1.1.1.32
      ✓ finds expected record for 1.1.1.3
      ✓ finds expected record for 1.1.1.5
      ✓ finds expected record for 1.1.1.7
      ✓ finds expected record for 1.1.1.9
      ✓ finds expected record for 1.1.1.15
      ✓ finds expected record for 1.1.1.17
      ✓ finds expected record for 1.1.1.31
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
    IP version: 6
      ✓ has all the correct metadata
      ✓ finds expected record for ::1:ffff:ffff
      ✓ finds expected record for ::2:0:0
      ✓ finds expected record for ::2:0:40
      ✓ finds expected record for ::2:0:50
      ✓ finds expected record for ::2:0:58
      ✓ finds expected record for ::2:0:1
      ✓ finds expected record for ::2:0:33
      ✓ finds expected record for ::2:0:39
      ✓ finds expected record for ::2:0:41
      ✓ finds expected record for ::2:0:49
      ✓ finds expected record for ::2:0:52
      ✓ finds expected record for ::2:0:57
      ✓ finds expected record for ::2:0:59
      ✓ finds expected record for 0:0:0:0:0:2:0:59
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ expects null for 89fa::
      IPv4 as IPv6
        ✓ IPv4 "translated" addresses should be looked up in the v4 DB
        ✓ IPv4 "mapped" addresses should be looked up in the v4 DB
    IP version: mixed
      ✓ has all the correct metadata
      ✓ finds expected record for 1.1.1.1
      ✓ finds expected record for 1.1.1.2
      ✓ finds expected record for 1.1.1.4
      ✓ finds expected record for 1.1.1.8
      ✓ finds expected record for 1.1.1.16
      ✓ finds expected record for 1.1.1.32
      ✓ finds expected record for 1.1.1.3
      ✓ finds expected record for 1.1.1.5
      ✓ finds expected record for 1.1.1.7
      ✓ finds expected record for 1.1.1.9
      ✓ finds expected record for 1.1.1.15
      ✓ finds expected record for 1.1.1.17
      ✓ finds expected record for 1.1.1.31
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ finds expected record for ::1:ffff:ffff
      ✓ finds expected record for ::2:0:0
      ✓ finds expected record for ::2:0:40
      ✓ finds expected record for ::2:0:50
      ✓ finds expected record for ::2:0:58
      ✓ finds expected record for ::2:0:1
      ✓ finds expected record for ::2:0:33
      ✓ finds expected record for ::2:0:39
      ✓ finds expected record for ::2:0:41
      ✓ finds expected record for ::2:0:49
      ✓ finds expected record for ::2:0:52
      ✓ finds expected record for ::2:0:57
      ✓ finds expected record for ::2:0:59
      ✓ finds expected record for 0:0:0:0:0:2:0:59
      ✓ expects null for 1.1.1.33
      ✓ expects null for 255.254.253.123
      ✓ expects null for 89fa::
      IPv4 as IPv6
        ✓ IPv4 "translated" addresses should be looked up in the v4 DB
        ✓ IPv4 "mapped" addresses should be looked up in the v4 DB

  Without IPv4 Search Tree
    ✓ finds expected record for 1.1.1.1
    ✓ finds expected record for 192.1.1.1

  Bad data
    Bad pointers
      ✓ throws with bad search tree
      ✓ throws with bad data section
    Broken doubles
      ✓ throws with bad double data

  Decoder
    Types
      ✓ decodes properly
      ✓ decodes booleans
      ✓ decodes bytes
      ✓ decodes utf8 strings
      ✓ decodes arrays
      ✓ decodes maps
      ✓ decodes doubles
      ✓ decodes floats
      ✓ decodes signed 32-bit ints
      ✓ decodes unsigned 16-bit ints
      ✓ decodes unsigned 32-bit ints
      ✓ decodes unsigned 64-bit ints
      ✓ decodes unsigned 128-bit ints
    Zeroes
      ✓ decodes properly
      ✓ decodes booleans
      ✓ decodes bytes
      ✓ decodes utf8 strings
      ✓ decodes arrays
      ✓ decodes maps
      ✓ decodes doubles
      ✓ decodes floats
      ✓ decodes signed 32-bit ints
      ✓ decodes unsigned 16-bit ints
      ✓ decodes unsigned 32-bit ints
      ✓ decodes unsigned 64-bit ints
      ✓ decodes unsigned 128-bit ints

  Constructor
    ✓ allows new
    ✓ allows not-new
    ✓ allows new with a buffer
    ✓ allows not-new with a buffer

  Opening
    #openSync()
      ✓ opens with a string
      ✓ opens with a buffer
    #open()
      ✓ opens with a string

  Bad DBs
    ✓ throws up when loading a nonexistent file (sync)
    ✓ throws up when loading a nonexistent file (async)
    ✓ doesn't get confused by a bad db file
    ✓ doesn't get confused by a bad db file (async)
    ✓ throws up when reloading a bad file (sync)
    ✓ throws up when reloading a bad file (async)

  Reload
    ✓ can reload (sync)
    ✓ can reload (async)
    ✓ can reload without a callback
    ✓ can reload same file (sync)
    ✓ can reload same file (async)
    ✓ can reload with a different file
    ✓ carries on if the file doesn't exist
    ✓ throws up if reloading without a file (sync)
    ✓ throws up if reloading without a file (async)


  272 passing (76ms)

Running memory test...
Initial RSS: 22667264

Testing cleanup...
Pass 0 RSS: 423059456
Pass 1 RSS: 428564480
Pass 2 RSS: 420392960
Pass 3 RSS: 424361984
Pass 4 RSS: 424337408
Pass 5 RSS: 447725568
Pass 6 RSS: 428974080
Pass 7 RSS: 429867008
Pass 8 RSS: 443437056
Pass 9 RSS: 439103488
Good!


Testing reloading...
Pass 0 RSS: 570429440
Pass 1 RSS: 588005376
Pass 2 RSS: 590147584
Pass 3 RSS: 585105408
Pass 4 RSS: 586661888
Pass 5 RSS: 584900608
Pass 6 RSS: 591818752
Pass 7 RSS: 583483392
Pass 8 RSS: 584957952
Pass 9 RSS: 586989568
Good!

Process finished with exit code 0
