### PR TITLE
Add Typescript typings to mmdb-reader

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,46 @@
+declare module 'mmdb-reader' {
+  import {Response} from "maxmind/lib/reader/response"
+  import {PathLike} from "fs"
+
+  export interface Record<T> {
+    value: T
+    ptr: number
+  }
+
+  export class Reader {
+    public constructor(buf: string | Buffer, filePath?: string)
+
+    public open(path: PathLike, cb: (err: Error, reader?: Reader) => void): void
+    public reload(file?: PathLike | undefined, cb?: (err: Error, reader?: Reader) => void): void
+    public reloadSync(file?: PathLike | undefined): void
+    public setup(): void
+    public findMetaPosition(): number
+    public readData(ptr: number): Record<any>
+    public cachedRead(ptr: number): Record<any>
+    public readPointer(ptr: number, size: number): Record<any>
+    public readString(ptr: number, size: number): Record<string>
+    public readDouble(ptr: number, size: number): Record<number>
+    public readBytes(ptr: number, size: number): Record<Buffer>
+    public readUInt16(ptr: number, size: number): Record<number>
+    public readUInt32(ptr: number, size: number): Record<number>
+    public readMap(ptr: number, mapLength: number): Record<any>
+    public readInt32(ptr: number, size: number): Record<number>
+    public readUInt64(ptr: number, size: number): Record<number>
+    public readUInt128(ptr: number, size: number): Record<number>
+    public readArray(ptr: number, size: number): Record<any[]>
+    public readBoolean(ptr: number, size: number): Record<boolean>
+    public readFloat(ptr: number, size: number): Record<number>
+    public setRecordSize(size: number): void
+    public readLeft24(idx: number): number
+    public readRight24(idx: number): number
+    public readLeft28(idx: number): number
+    public readRight28(idx: number): number
+    public readLeft32(idx: number): number
+    public readRight32(idx: number): number
+    public findIPv4StartPointer(): number
+    public lookup(addr: string): Response
+
+    public static open(path: PathLike, cb: (err: Error, reader?: Reader) => void): void
+    public static openSync (buf: string | Buffer, filePath?: string): Reader // Same as Reader constructor
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module 'mmdb-reader' {
     ptr: number
   }
 
-  export class Reader {
+  export default class Reader {
     public constructor(buf: string | Buffer, filePath?: string)
 
     public open(path: PathLike, cb: (err: Error, reader?: Reader) => void): void

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "big-integer": "^1.5.4",
-    "hashlru": "^2.0.0"
+    "hashlru": "^2.0.0",
+    "maxmind": "^3.1.2"
   }
 }


### PR DESCRIPTION
Hi, 
I am using this module in a Typescript project, and in order to have a better integration with it, I've implemented the type definitions.

It uses also the Maxmind's own project to have their database definitions, so I've needed to add it as a dependency.

Cheers,
Caio